### PR TITLE
Fix #49 Add return value to the functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Regional granularity levels in Norway which are depicted by differe
              Identifying when codes have changed and how many changes have taken place
              can be troublesome. This package will help to identify these changes and when the changes
              have taken place. One of the limitation of this package is that it is heavily depending 
-             on the codes available from SSB website. 
+             on the codes available from SSB website <https://data.ssb.no/api/klass/v1/api-guide.html>.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/cast-geo.R
+++ b/R/cast-geo.R
@@ -1,11 +1,16 @@
-#' Cast geo granularity from API
+#' @title Cast geo granularity from API
 #'
-#' Add geo granularity levels to all sides
+#' @description Add geo granularity levels to all sides
 #'
 #' @param year Which year the codes are valid from. If NULL then current year
 #'   will be selected.
 #'
 #' @import data.table
+#' @return A dataset of class `data.table` representing the spreading of
+#'   different geographical levels from lower to higher levels ie. from
+#'   enumeration area codes to county codes, for the selected year.
+#' @examples
+#  DT <- cast_geo(2020)
 #' @export
 
 cast_geo <- function(year = NULL) {
@@ -101,6 +106,10 @@ cast_geo <- function(year = NULL) {
 #'   year before before previous year etc..etc.. This function is needed
 #'   when running [cast_geo()].
 #' @inheritParams get_correspond
+#' @return A dataset of class `data.table` representing the lower geographical
+#'   level codes and their corresponding higher geographical levels. For example
+#'   for codes on enumeration areas and their corresponding codes for
+#'   municipalities or town.
 #' @export
 find_correspond <- function(type, correspond, from) {
   ## type: Higher granularity eg. fylker
@@ -117,6 +126,9 @@ find_correspond <- function(type, correspond, from) {
   message("Data for ", correspond, " to ", type, " is from ", stat$from, " with ", stat$rows, " rows")
   return(dt)
 }
+
+
+## Helper ------------------------------------------------------
 
 ## Grunnkrets that only exist in previous year need to be added if changes
 ## only happpened previous years from find_correspond. eg. 15390107
@@ -141,8 +153,6 @@ merge_geo <- function(dt, cor, geo, year){
   DT[, c("sourceCode", "sourceName", "targetName") := NULL]
 }
 
-
-## Helper ------------------------------------------------------
 ## Some years have missing code eg. 10199999 for grunnkrets, but when not available
 ## then add it manually
 recode_missing_gr <- function(dt){

--- a/R/get-change.R
+++ b/R/get-change.R
@@ -6,10 +6,15 @@
 #' \href{https://data.ssb.no/api/klass/v1/api-guide.html#_changes}{KLASS} is that you
 #' can get all code changes for several years at once.
 #'
-#' @param code TRUE will only track code changes. Else change name only will also be considered as change.
-#' @param quiet TRUE will suppress messages when no changes happened for a specific time range
+#' @param code TRUE will only track code changes. Else change name only will
+#'   also be considered as change.
+#' @param quiet TRUE will suppress messages when no changes happened for a
+#'   specific time range
 #' @inheritParams get_code
-#'
+#' @return A dataset of class `data.table` consisting old and new code with
+#'   the respective year when the codes have changed
+#' @examples
+#' DT <- get_change("kommune", from = 2018, to = 2020)
 #' @export
 
 get_change <- function(type = c(

--- a/R/get-code.R
+++ b/R/get-code.R
@@ -5,7 +5,8 @@
 #' @param type Type of regional granularity ie. fylke, kommune etc.
 #' @param date If TRUE then give complete date else year only
 #' @inheritParams get_correspond
-#'
+#' @return A dataset of class `data.table` consisting codes of selected
+#'   geographical level and the duration the codes are valid ie. from and to.
 #' @import data.table
 #'
 #' @export

--- a/R/get-correspond.R
+++ b/R/get-correspond.R
@@ -1,16 +1,22 @@
 #' Get geo corresponds
 #'
-#' This function will get the corresponding geo code of specific granularity via API from SSB whenever available.
+#' This function will get the corresponding geo code of specific granularity via
+#' API from SSB whenever available.
 #'
 #' @param type Higher granularity from specified correspond arg.
 #' @param correspond Lower granularity from the specified type arg.
-#' @param from Specify the starting year for range period. Current year is the default.
-#' @param to Specify the year to end the range period. Current year is used when not specified.
+#' @param from Specify the starting year for range period. Current year is the
+#'   default.
+#' @param to Specify the year to end the range period. Current year is used when
+#'   not specified.
 #' @param dt Output as data.table
-#'
+#' @return A dataset of class `data.table` representing the lower geographical
+#'   level codes and their corresponding higher geographical levels. For example
+#'   for codes on enumeration areas and their corresponding codes for
+#'   municipalities or town.
 #' @examples
 #' \dontrun{
-#' df <- get_correspond("fylke", "kommune", 2020)
+#' df <- get_correspond("kommune", "grunnkrets", 2020)
 #' }
 #'
 #' @export

--- a/R/track-change.R
+++ b/R/track-change.R
@@ -6,7 +6,10 @@
 #' be used.
 #'
 #' @inheritParams get_code
-#' @return dataApi environment with main objects ie. dc (data change) and dt (current data)
+#' @return A dataset of class `data.table` consisting all older codes from
+#'   previous years until the selected year in `to` argument and what these
+#'   older codes were changed into. If the codes have not changed then the value
+#'   of old code will be `NA`.
 #'
 #' @examples
 #' \dontrun{

--- a/R/track-merge.R
+++ b/R/track-merge.R
@@ -2,6 +2,8 @@
 #'
 #' @inheritParams get_code
 #' @return Dataset with column 'merge' showing how many the codes have been merged to
+#' @examples
+#'  dt <- track_change("kommune", 2018, 2020)
 #' @export
 
 track_merge <- function(type = c(

--- a/R/track-split.R
+++ b/R/track-split.R
@@ -1,7 +1,9 @@
 #' Get geo code that are split after code change
 #'
 #' @inheritParams get_code
-#' @return Dataset with column 'split' showing how many the codes have been split to
+#' @return Dataset of class `data.table` with column 'split' showing how many the codes have been split to
+#' @examples
+#'  dt <- track_split("kommune", 2018, 2020)
 #' @export
 
 track_split <- function(type = c(

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
              Identifying when codes have changed and how many changes have taken place
              can be troublesome. This package will help to identify these changes and when the changes
              have taken place. One of the limitation of this package is that it is heavily depending 
-             on the codes available from SSB website. ">
+             on the codes available from SSB website &lt;https://data.ssb.no/api/klass/v1/api-guide.html&gt;.">
 <meta property="og:image" content="/logo.png">
 <!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -6,5 +6,5 @@ articles:
   code-change: code-change.html
   granularity: granularity.html
   use-api: use-api.html
-last_built: 2021-10-29T12:22Z
+last_built: 2021-11-10T15:52Z
 

--- a/docs/reference/cast_geo.html
+++ b/docs/reference/cast_geo.html
@@ -161,6 +161,11 @@ will be selected.</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>A dataset of class <code>data.table</code> representing the spreading of
+different geographical levels from lower to higher levels ie. from
+enumeration area codes to county codes, for the selected year.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/find_correspond.html
+++ b/docs/reference/find_correspond.html
@@ -174,10 +174,17 @@ when running <code><a href='cast_geo.html'>cast_geo()</a></code>.</p>
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>A dataset of class <code>data.table</code> representing the lower geographical
+level codes and their corresponding higher geographical levels. For example
+for codes on enumeration areas and their corresponding codes for
+municipalities or town.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/get_change.html
+++ b/docs/reference/get_change.html
@@ -175,19 +175,23 @@ can get all code changes for several years at once.</p>
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     <tr>
       <th>code</th>
-      <td><p>TRUE will only track code changes. Else change name only will also be considered as change.</p></td>
+      <td><p>TRUE will only track code changes. Else change name only will
+also be considered as change.</p></td>
     </tr>
     <tr>
       <th>quiet</th>
-      <td><p>TRUE will suppress messages when no changes happened for a specific time range</p></td>
+      <td><p>TRUE will suppress messages when no changes happened for a
+specific time range</p></td>
     </tr>
     <tr>
       <th>date</th>
@@ -195,7 +199,14 @@ can get all code changes for several years at once.</p>
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
+    <p>A dataset of class <code>data.table</code> consisting old and new code with
+the respective year when the codes have changed</p>
+
+    <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
+    <pre class="examples"><div class='input'><span class='va'>DT</span> <span class='op'>&lt;-</span> <span class='fu'>get_change</span><span class='op'>(</span><span class='st'>"kommune"</span>, from <span class='op'>=</span> <span class='fl'>2018</span>, to <span class='op'>=</span> <span class='fl'>2020</span><span class='op'>)</span>
+</div><div class='output co'>#&gt; </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/get_code.html
+++ b/docs/reference/get_code.html
@@ -165,11 +165,13 @@
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     <tr>
       <th>date</th>
@@ -177,6 +179,10 @@
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>A dataset of class <code>data.table</code> consisting codes of selected
+geographical level and the duration the codes are valid ie. from and to.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/get_correspond.html
+++ b/docs/reference/get_correspond.html
@@ -47,7 +47,8 @@
 
 
 <meta property="og:title" content="Get geo corresponds — get_correspond" />
-<meta property="og:description" content="This function will get the corresponding geo code of specific granularity via API from SSB whenever available." />
+<meta property="og:description" content="This function will get the corresponding geo code of specific granularity via
+API from SSB whenever available." />
 <meta property="og:image" content="/logo.png" />
 
 
@@ -146,7 +147,8 @@
     </div>
 
     <div class="ref-description">
-    <p>This function will get the corresponding geo code of specific granularity via API from SSB whenever available.</p>
+    <p>This function will get the corresponding geo code of specific granularity via
+API from SSB whenever available.</p>
     </div>
 
     <pre class="usage"><span class='fu'>get_correspond</span><span class='op'>(</span>
@@ -170,11 +172,13 @@
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     <tr>
       <th>dt</th>
@@ -182,10 +186,16 @@
     </tr>
     </table>
 
+    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+
+    <p>A dataset of class <code>data.table</code> representing the lower geographical
+level codes and their corresponding higher geographical levels. For example
+for codes on enumeration areas and their corresponding codes for
+municipalities or town.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> <span class='op'>(</span><span class='cn'>FALSE</span><span class='op'>)</span> <span class='op'>{</span>
-<span class='va'>df</span> <span class='op'>&lt;-</span> <span class='fu'>get_correspond</span><span class='op'>(</span><span class='st'>"fylke"</span>, <span class='st'>"kommune"</span>, <span class='fl'>2020</span><span class='op'>)</span>
+<span class='va'>df</span> <span class='op'>&lt;-</span> <span class='fu'>get_correspond</span><span class='op'>(</span><span class='st'>"kommune"</span>, <span class='st'>"grunnkrets"</span>, <span class='fl'>2020</span><span class='op'>)</span>
 <span class='op'>}</span>
 
 </div></pre>

--- a/docs/reference/track_change.html
+++ b/docs/reference/track_change.html
@@ -170,17 +170,22 @@ be used.</p>
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     </table>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>dataApi environment with main objects ie. dc (data change) and dt (current data)</p>
+    <p>A dataset of class <code>data.table</code> consisting all older codes from
+previous years until the selected year in <code>to</code> argument and what these
+older codes were changed into. If the codes have not changed then the value
+of old code will be <code>NA</code>.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> <span class='op'>(</span><span class='cn'>FALSE</span><span class='op'>)</span> <span class='op'>{</span>

--- a/docs/reference/track_merge.html
+++ b/docs/reference/track_merge.html
@@ -164,11 +164,13 @@
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     </table>
 
@@ -176,6 +178,9 @@
 
     <p>Dataset with column 'merge' showing how many the codes have been merged to</p>
 
+    <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
+    <pre class="examples"><div class='input'> <span class='va'>dt</span> <span class='op'>&lt;-</span> <span class='fu'><a href='track_change.html'>track_change</a></span><span class='op'>(</span><span class='st'>"kommune"</span>, <span class='fl'>2018</span>, <span class='fl'>2020</span><span class='op'>)</span>
+</div><div class='output co'>#&gt; </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/track_split.html
+++ b/docs/reference/track_split.html
@@ -164,18 +164,23 @@
     </tr>
     <tr>
       <th>from</th>
-      <td><p>Specify the starting year for range period. Current year is the default.</p></td>
+      <td><p>Specify the starting year for range period. Current year is the
+default.</p></td>
     </tr>
     <tr>
       <th>to</th>
-      <td><p>Specify the year to end the range period. Current year is used when not specified.</p></td>
+      <td><p>Specify the year to end the range period. Current year is used when
+not specified.</p></td>
     </tr>
     </table>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>Dataset with column 'split' showing how many the codes have been split to</p>
+    <p>Dataset of class <code>data.table</code> with column 'split' showing how many the codes have been split to</p>
 
+    <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
+    <pre class="examples"><div class='input'> <span class='va'>dt</span> <span class='op'>&lt;-</span> <span class='fu'>track_split</span><span class='op'>(</span><span class='st'>"kommune"</span>, <span class='fl'>2018</span>, <span class='fl'>2020</span><span class='op'>)</span>
+</div><div class='output co'>#&gt; </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/man/cast_geo.Rd
+++ b/man/cast_geo.Rd
@@ -10,6 +10,11 @@ cast_geo(year = NULL)
 \item{year}{Which year the codes are valid from. If NULL then current year
 will be selected.}
 }
+\value{
+A dataset of class \code{data.table} representing the spreading of
+different geographical levels from lower to higher levels ie. from
+enumeration area codes to county codes, for the selected year.
+}
 \description{
 Add geo granularity levels to all sides
 }

--- a/man/find_correspond.Rd
+++ b/man/find_correspond.Rd
@@ -11,7 +11,14 @@ find_correspond(type, correspond, from)
 
 \item{correspond}{Lower granularity from the specified type arg.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
+}
+\value{
+A dataset of class \code{data.table} representing the lower geographical
+level codes and their corresponding higher geographical levels. For example
+for codes on enumeration areas and their corresponding codes for
+municipalities or town.
 }
 \description{
 Unlike \code{\link[=get_correspond]{get_correspond()}} functions, this function will find existing

--- a/man/get_change.Rd
+++ b/man/get_change.Rd
@@ -16,15 +16,23 @@ get_change(
 \arguments{
 \item{type}{Type of regional granularity ie. fylke, kommune etc.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 
-\item{code}{TRUE will only track code changes. Else change name only will also be considered as change.}
+\item{code}{TRUE will only track code changes. Else change name only will
+also be considered as change.}
 
-\item{quiet}{TRUE will suppress messages when no changes happened for a specific time range}
+\item{quiet}{TRUE will suppress messages when no changes happened for a
+specific time range}
 
 \item{date}{If TRUE then give complete date else year only}
+}
+\value{
+A dataset of class \code{data.table} consisting old and new code with
+the respective year when the codes have changed
 }
 \description{
 This function will download all registered geo code changes from SSB via API. Basically it's the data you
@@ -32,4 +40,7 @@ can see \href{https://www.ssb.no/klass/klassifikasjoner/131/endringer}{here} if 
 for code change in munucipality (\emph{kommune}). The advantage of using \code{get_change} or
 \href{https://data.ssb.no/api/klass/v1/api-guide.html#_changes}{KLASS} is that you
 can get all code changes for several years at once.
+}
+\examples{
+DT <- get_change("kommune", from = 2018, to = 2020)
 }

--- a/man/get_code.Rd
+++ b/man/get_code.Rd
@@ -14,11 +14,17 @@ get_code(
 \arguments{
 \item{type}{Type of regional granularity ie. fylke, kommune etc.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 
 \item{date}{If TRUE then give complete date else year only}
+}
+\value{
+A dataset of class \code{data.table} consisting codes of selected
+geographical level and the duration the codes are valid ie. from and to.
 }
 \description{
 This function will download the codes of selected geographical levels via API.

--- a/man/get_correspond.Rd
+++ b/man/get_correspond.Rd
@@ -17,18 +17,27 @@ get_correspond(
 
 \item{correspond}{Lower granularity from the specified type arg.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 
 \item{dt}{Output as data.table}
 }
+\value{
+A dataset of class \code{data.table} representing the lower geographical
+level codes and their corresponding higher geographical levels. For example
+for codes on enumeration areas and their corresponding codes for
+municipalities or town.
+}
 \description{
-This function will get the corresponding geo code of specific granularity via API from SSB whenever available.
+This function will get the corresponding geo code of specific granularity via
+API from SSB whenever available.
 }
 \examples{
 \dontrun{
-df <- get_correspond("fylke", "kommune", 2020)
+df <- get_correspond("kommune", "grunnkrets", 2020)
 }
 
 }

--- a/man/track_change.Rd
+++ b/man/track_change.Rd
@@ -13,12 +13,17 @@ track_change(
 \arguments{
 \item{type}{Type of regional granularity ie. fylke, kommune etc.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 }
 \value{
-dataApi environment with main objects ie. dc (data change) and dt (current data)
+A dataset of class \code{data.table} consisting all older codes from
+previous years until the selected year in \code{to} argument and what these
+older codes were changed into. If the codes have not changed then the value
+of old code will be \code{NA}.
 }
 \description{
 Track all code changes until current year or the year specified in \code{to} argument.

--- a/man/track_merge.Rd
+++ b/man/track_merge.Rd
@@ -13,13 +13,18 @@ track_merge(
 \arguments{
 \item{type}{Type of regional granularity ie. fylke, kommune etc.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 }
 \value{
 Dataset with column 'merge' showing how many the codes have been merged to
 }
 \description{
 Get geo code that are merged after code change
+}
+\examples{
+ dt <- track_change("kommune", 2018, 2020)
 }

--- a/man/track_split.Rd
+++ b/man/track_split.Rd
@@ -13,13 +13,18 @@ track_split(
 \arguments{
 \item{type}{Type of regional granularity ie. fylke, kommune etc.}
 
-\item{from}{Specify the starting year for range period. Current year is the default.}
+\item{from}{Specify the starting year for range period. Current year is the
+default.}
 
-\item{to}{Specify the year to end the range period. Current year is used when not specified.}
+\item{to}{Specify the year to end the range period. Current year is used when
+not specified.}
 }
 \value{
-Dataset with column 'split' showing how many the codes have been split to
+Dataset of class \code{data.table} with column 'split' showing how many the codes have been split to
 }
 \description{
 Get geo code that are split after code change
+}
+\examples{
+ dt <- track_split("kommune", 2018, 2020)
 }

--- a/memo/cran-comments.md
+++ b/memo/cran-comments.md
@@ -1,2 +1,18 @@
 ## R CMD check results
 There were no ERRORs, WARNINGs or NOTEs
+
+## Second submit
+Please provide a link to the used webservices to the description field of your DESCRIPTION file in the form <http:...> or <https:...> with angle brackets for auto-linking and no space after 'http:' and 'https:'.
+
+Please add \value to .Rd files regarding exported methods and explain the functions results in the documentation. Please write about the structure of the output (class) and also what the output means. (If a function does not return a value, please document that too, e.g. 
+\value{No return value, called for side effects} or similar) Missing Rd-tags in up to 14 .Rd files, e.g.:
+      cast_geo.Rd: \value
+      find_change.Rd: \value
+      find_correspond.Rd: \value
+      geo_cast.Rd: \value
+      geo_change.Rd: \value
+      geo_merge.Rd: \value
+      ...
+
+
+Please fix and resubmit.


### PR DESCRIPTION
Feedback from first CRAN submission:

> Please provide a link to the used webservices to the description field of your DESCRIPTION file in the form <http:...> or <https:...> with angle brackets for auto-linking and no space after 'http:' and 'https:'.
> 
> Please add \value to .Rd files regarding exported methods and explain the functions results in the documentation. Please write about the structure of the output (class) and also what the output means. (If a function does not return a value, please document that too, e.g. 
> \value{No return value, called for side effects} or similar) Missing Rd-tags in up to 14 .Rd files, e.g.:
>       cast_geo.Rd: \value
>       find_change.Rd: \value
>       find_correspond.Rd: \value
>       geo_cast.Rd: \value
>       geo_change.Rd: \value
>       geo_merge.Rd: \value
>       ...
> 
> 
> Please fix and resubmit.
