### PR TITLE
handle when ssb klass is not published

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # norgeo 2.4.7
 - Bugfix: Handle splitting of grunnkrets when the old code was reused. 
 - In the manual fix, oldCodes existing as currentCodes are removed to prevent recoding of valid codes
+- Bugfix: get_code does not fail if table is not published in SSB KLASS (e.g. levekaar 2024)
 
 # norgeo 2.4.6
 - Bugfix: `cast_geo` no longer maps levekaar to bydel, as levekaar spanning across bydel caused duplicates in the list. 

--- a/R/get-code.R
+++ b/R/get-code.R
@@ -113,9 +113,12 @@ set_url <- function(base = NULL,
 
   koReg <- httr2::request(endUrl) |>
     httr2::req_url_query(!!!codeQry) |>
-    httr2::req_retry(max_tries = 5) |>
-    httr2::req_perform()
-
+    httr2::req_retry(max_tries = 5) 
+  
+  ison <- check_online(koReg)
+  if(!ison) return(data.table::data.table())
+  
+  koReg <- httr2::req_perform(koReg)
   koDT <- koReg |> httr2::resp_body_json(simplifyDataFrame = TRUE)
   koDT <- data.table::as.data.table(koDT)
 
@@ -124,6 +127,13 @@ set_url <- function(base = NULL,
   data.table::setnames(koDT, koNames, koNewNames)
 
   return(koDT)
+}
+
+check_online <- function(koReg){
+  con <- url(koReg$url)
+  check <- suppressWarnings(try(open.connection(con, open = "rt", timeout = TRUE), silent = TRUE))
+  suppressWarnings(try(close.connection(con), silent = TRUE))
+  ifelse(is.null(check), TRUE, FALSE)
 }
 
 ## Ensure date is the required format


### PR DESCRIPTION
Dette ser ut til å fungere fint. tabellen for levekårssoner for 2024 er ikke publisert (andre år er det publisert en tom tabell, men for 2024 feiler spørringen). 

Har lagt inn en sjekk om at url eksisterer, og om den ikke eksisterer vil det bli laget en tom data.table for dette geonivået. 

Sjekk om det ser ok ut. 